### PR TITLE
Fix concurrent launch calls

### DIFF
--- a/packages/playwright-cloudflare/src/cloudflare/index.ts
+++ b/packages/playwright-cloudflare/src/cloudflare/index.ts
@@ -3,22 +3,17 @@ import fs from 'fs';
 import { createInProcessPlaywright } from 'playwright-core/lib/inProcessFactory';
 
 import type { Browser, BrowserWorker, WorkersLaunchOptions } from '../..';
-import { kBrowserConnectParams } from './webSocketTransport';
+import { storageManager } from './webSocketTransport';
 
 const FAKE_HOST = 'ws://fake.host';
 
 const playwright = createInProcessPlaywright();
 
 export async function launch(endpoint: BrowserWorker, options?: WorkersLaunchOptions): Promise<Browser> {
-  if ((globalThis as any)[kBrowserConnectParams])
-    throw new Error('It seems like you are trying to launch while another launch is in progress');
-  // TODO huge hack to pass the cloudflare params to webSocketTransport
-  (globalThis as any)[kBrowserConnectParams] = { endpoint, options };
-  try {
-    return await playwright.chromium.connectOverCDP(FAKE_HOST) as Browser;
-  } finally {
-    delete (globalThis as any)[kBrowserConnectParams];
-  }
+  // keeps the endpoint and options for client -> server async communication
+  return await storageManager.run({ endpoint, options }, 
+    async () => await playwright.chromium.connectOverCDP(FAKE_HOST) as Browser
+  );
 }
 
 export { fs };


### PR DESCRIPTION
It's not possible to pass unserializable data from playwright client to playwright server, so we pass parameters using `AsyncLocalStorage`.