### PR TITLE
chore: ensure session management api is exposed in default export

### DIFF
--- a/packages/playwright-cloudflare/index.d.ts
+++ b/packages/playwright-cloudflare/index.d.ts
@@ -116,4 +116,13 @@ export async function history(endpoint: BrowserWorker): Promise<ClosedSession[]>
  */
 export async function limits(endpoint: BrowserWorker): Promise<LimitsResponse>;
 
-export default Playwright;
+declare const playwright: Pick<Playwright, 'chromium' | 'selectors' | 'devices' | 'errors' | 'request'> & {
+  connect,
+  launch,
+  limits,
+  sessions,
+  history,
+  acquire,
+};
+
+export default playwright;

--- a/packages/playwright-cloudflare/src/index.ts
+++ b/packages/playwright-cloudflare/src/index.ts
@@ -123,4 +123,16 @@ export const devices = playwright.devices;
 export const errors = playwright.errors;
 export const request = playwright.request;
 
-export default playwright;
+export default {
+  chromium,
+  selectors,
+  devices,
+  errors,
+  request,
+  launch,
+  connect,
+  sessions,
+  history,
+  acquire,
+  limits,
+};


### PR DESCRIPTION
tests added to check keep_alive and limits