### PR TITLE
fix: mock open package

### DIFF
--- a/packages/playwright-cloudflare/src/mocks/open.ts
+++ b/packages/playwright-cloudflare/src/mocks/open.ts
@@ -1,0 +1,3 @@
+export default function open() {
+  throw new Error('Not implemented');
+}

--- a/packages/playwright-cloudflare/utils/build_bundles.js
+++ b/packages/playwright-cloudflare/utils/build_bundles.js
@@ -51,6 +51,7 @@ const basedir = path.dirname(fileURLToPath(import.meta.url));
 
           'commander': path.join(basedir, '../src/mocks/commander'),
           'socks-proxy-agent': path.join(basedir, '../src/mocks/socksProxyAgent'),
+          'open': path.join(basedir, '../src/mocks/open'),
 
           ...(name === 'pngjs' ? { 'zlib': 'browserify-zlib' } :
           { 'pngjs': path.join(basedir, `../src/bundles/pngjs.js` ) }),


### PR DESCRIPTION
Cloudflare workers doesn't support open and besides it uses __dirname, which fails on load