### PR TITLE
fix: replace fs.promises.mkdtemp with mkdir for Workers compatibility

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -155,7 +155,8 @@ export abstract class BrowserType extends SdkObject {
     await this._createArtifactDirs(options);
 
     const tempDirectories: string[] = [];
-    const artifactsDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'playwright-artifacts-'));
+    const artifactsDir = path.join(os.tmpdir(), 'playwright-artifacts-' + Math.random().toString(36).slice(2));
+    await fs.promises.mkdir(artifactsDir, { recursive: true });
     tempDirectories.push(artifactsDir);
 
     if (userDataDir) {
@@ -164,7 +165,8 @@ export abstract class BrowserType extends SdkObject {
       if (!await existsAsync(userDataDir))
         await fs.promises.mkdir(userDataDir, { recursive: true, mode: 0o700 });
     } else {
-      userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), `playwright_${this._name}dev_profile-`));
+      userDataDir = path.join(os.tmpdir(), `playwright_${this._name}dev_profile-` + Math.random().toString(36).slice(2));
+      await fs.promises.mkdir(userDataDir, { recursive: true });
       tempDirectories.push(userDataDir);
     }
     await this.prepareUserDataDir(options, userDataDir);

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -89,7 +89,8 @@ export class Chromium extends BrowserType {
     else if (headersMap && !Object.keys(headersMap).some(key => key.toLowerCase() === 'user-agent'))
       headersMap['User-Agent'] = getUserAgent();
 
-    const artifactsDir = await progress.race(fs.promises.mkdtemp(ARTIFACTS_FOLDER));
+    const artifactsDir = ARTIFACTS_FOLDER + Math.random().toString(36).slice(2);
+    await progress.race(fs.promises.mkdir(artifactsDir, { recursive: true }));
     const doCleanup = async () => {
       await removeFolders([artifactsDir]);
       const cb = onClose;


### PR DESCRIPTION
## Summary

- Replace `fs.promises.mkdtemp` with `fs.promises.mkdir` + random suffix in 3 call sites
- Fixes runtime crash when using `@cloudflare/playwright` in a Cloudflare Worker

## Problem

Cloudflare Workers' `nodejs_compat` (via unenv) does **not** implement `fs.mkdtemp` or `fs.promises.mkdtemp`. When deploying the Playwright MCP example (or any Worker using `@cloudflare/playwright`), the Worker crashes at runtime with an error like:

```
TypeError: fs.promises.mkdtemp is not a function
```

This affects `@cloudflare/playwright@1.1.2` (and likely earlier versions).

## Fix

Replace `mkdtemp(prefix)` with `mkdir(prefix + randomSuffix, { recursive: true })` in:

| File | Line | Description |
|------|------|-------------|
| `packages/playwright-core/src/server/browserType.ts` | 158 | Artifacts directory creation |
| `packages/playwright-core/src/server/browserType.ts` | 167 | User data directory creation |
| `packages/playwright-core/src/server/chromium/chromium.ts` | 92 | CDP artifacts directory creation |

The random suffix uses `Math.random().toString(36).slice(2)`, providing sufficient uniqueness for temporary directory names while using only `fs.promises.mkdir` which IS available in Workers.

## Requires

`compatibility_date >= 2025-09-23` in the Worker's `wrangler.toml` for `fs.promises.mkdir` to be available.

## Testing

Verified by deploying the `cloudflare/playwright-mcp` example Worker with these changes patched via `patch-package`. The Worker successfully launches browsers, navigates pages, and takes screenshots without any `mkdtemp`-related errors.