### PR TITLE
Rename Browser Rendering to Browser Run in README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Playwright for Browser Rendering
+# Playwright for Browser Run
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/playwright/tree/main/packages/playwright-cloudflare/examples/todomvc)
 
-Fork of [Playwright](https://github.com/microsoft/playwright/) that was modified to be compatible with [Cloudflare Workers](https://developers.cloudflare.com/workers/) and [Browser Rendering](https://developers.cloudflare.com/browser-rendering/).
+Fork of [Playwright](https://github.com/microsoft/playwright/) that was modified to be compatible with [Cloudflare Workers](https://developers.cloudflare.com/workers/) and [Browser Run](https://developers.cloudflare.com/browser-rendering/) (formerly Browser Rendering).
 
 🏷️ Upstream Playwright version: [1.58.2](https://github.com/microsoft/playwright/releases/tag/v1.58.2)
 

--- a/packages/playwright-cloudflare/package.json
+++ b/packages/playwright-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/playwright",
-  "description": "Playwright for Cloudflare Workers",
+  "description": "Playwright for Cloudflare Browser Run (formerly Browser Rendering)",
   "version": "1.0.0-next",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Updates user-facing references from Browser Rendering to Browser Run as part of the product rename (Agents Week 2026).

### Changes
- **README.md**: Title updated to "Playwright for Browser Run", description with bridge phrasing
- **packages/playwright-cloudflare/package.json**: Description field updated

Per the [rename checklist](https://wiki.cfdata.org/spaces/BRAPI/pages/1369204026/Browser+Run+Rename+Checklist).

beep-boop-🤖