### PR TITLE
fix: lazy-load cloudflare:workers to support non-Worker runtimes

### DIFF
--- a/.github/workflows/cf_prerelease.yml
+++ b/.github/workflows/cf_prerelease.yml
@@ -22,4 +22,5 @@ jobs:
           git submodule update --init
           cd packages/playwright-cloudflare
           npm run build
+          npm run test:node-import
           npx pkg-pr-new publish

--- a/packages/playwright-cloudflare/package.json
+++ b/packages/playwright-cloudflare/package.json
@@ -29,6 +29,7 @@
     "ci:tests": "cd tests && npm ci",
     "build:bundles": "node utils/build_bundles.js",
     "build:types": "node utils/copy_types.js",
+    "test:node-import": "node tests/node-import.mjs",
     "build": "npm run generate-injected:core && npm run ci:bundles && npm run build:bundles && npm run build:types && npx vite build",
     "test:generate:worker": "node ./utils/generate_worker_tests.js && cd tests && npx vite build",
     "test:generate:proxy": "node ./utils/generate_proxy_tests.js",

--- a/packages/playwright-cloudflare/src/index.ts
+++ b/packages/playwright-cloudflare/src/index.ts
@@ -1,6 +1,5 @@
 import { createInProcessPlaywright } from 'playwright-core/lib/inProcessFactory';
 import { kBrowserCloseMessageId } from 'playwright-core/lib/server/chromium/crConnection';
-import { env } from 'cloudflare:workers';
 import { setTimeOrigin, timeOrigin } from 'playwright-core/lib/utils/isomorphic/time';
 
 import { transportZone, WebSocketTransport } from './cloudflare/webSocketTransport';
@@ -12,6 +11,23 @@ import type { ProtocolRequest } from 'playwright-core/lib/server/transport';
 import type { CRBrowser } from 'playwright-core/lib/server/chromium/crBrowser';
 import type { AcquireResponse, ActiveSession, Browser, BrowserBindingKey, BrowserEndpoint, BrowserWorker, ClosedSession, ConnectOverCDPOptions, HistoryResponse, LimitsResponse, SessionsResponse, WorkersLaunchOptions } from '..';
 import type { ChannelOwner } from 'playwright-core/lib/client/channelOwner';
+
+// Resolve cloudflare:workers env lazily so the module can load in
+// non-Worker runtimes (Node.js, Deno, Bun). Uses createRequire for
+// ESM compliance. Falls back to empty object when not in Workers.
+let _env: Record<string, any> | null = null;
+function getEnv(): Record<string, any> {
+  if (_env === null) {
+    try {
+      const { createRequire } = require('node:module');
+      const cjsRequire = createRequire(import.meta.url);
+      _env = cjsRequire('cloudflare:workers').env ?? {};
+    } catch {
+      _env = {};
+    }
+  }
+  return _env;
+}
 
 function resetMonotonicTime() {
   // performance.timeOrigin is always 0 in Cloudflare Workers. Besides, Date.now() is 0 in global scope,
@@ -75,6 +91,7 @@ function extractOptions(endpoint: BrowserEndpoint): { sessionId?: string, keep_a
 }
 
 export function endpointURLString(binding: BrowserWorker | BrowserBindingKey, options?: { sessionId?: string, persistent?: boolean, keepAlive?: number }): string {
+  const env = getEnv();
   const bindingKey = typeof binding === 'string' ? binding : Object.keys(env).find(key => (env as any)[key] === binding);
   if (!bindingKey || !(bindingKey in env))
     throw new Error(`No binding found for ${binding}`);
@@ -101,6 +118,7 @@ async function createBrowser(transport: WebSocketTransport, options?: { persiste
 }
 
 function getBrowserBinding(endpoint: BrowserEndpoint): BrowserWorker {
+  const env = getEnv();
   if (typeof endpoint === 'string' || endpoint instanceof URL) {
     const url = endpoint instanceof URL ? endpoint : new URL(endpoint);
     const binding = url.searchParams.get('browser_binding') as BrowserBindingKey;

--- a/packages/playwright-cloudflare/tests/node-import.mjs
+++ b/packages/playwright-cloudflare/tests/node-import.mjs
@@ -1,0 +1,6 @@
+const { chromium } = await import('../lib/index.js');
+
+if (typeof chromium.connectOverCDP !== 'function')
+  throw new Error('Expected chromium.connectOverCDP to be available');
+
+console.log('Cloudflare Playwright imports successfully outside Workers');


### PR DESCRIPTION
## Problem

I ran into this when loading `@cloudflare/playwright` from Node.js, Deno, and Bun: the top-level `cloudflare:workers` import crashes before `connectOverCDP()` can be used with an external CDP endpoint.

**Reproduction:** https://github.com/LordCoughmann/repo-cf-playwright-lazy-import

```bash
pnpm install
node index.mjs
# → Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported
```

## Solution

I worked around this in my own fork by resolving `cloudflare:workers` lazily only when Browser Binding functions are called. This keeps Worker behavior unchanged while allowing the package to load in non-Worker runtimes; invalid Browser Binding calls still report the existing `No binding found for ...` error.

## Validation

- Existing package build and focused checks pass.
- `npm run test:node-import` passes from the non-Worker package directory.
- The import smoke test verifies that `chromium.connectOverCDP` is available outside Workers.

Refs: #88, #59
