### PR TITLE
feat: support external WebSocket CDP endpoints

### DIFF
--- a/packages/playwright-cloudflare/src/index.ts
+++ b/packages/playwright-cloudflare/src/index.ts
@@ -32,13 +32,14 @@ const originalConnectOverCDP = playwright.chromium.connectOverCDP;
 // HACK this is a major hack, but we need it to make playwright-mcp and stagehand work without modifying their code extensively.
 // Both playwright-mcp and stagehand use playwright.chromium.connectOverCDP if a CDP endpoint is passed,
 // so we need to override it to use our own connectOverCDP implementation.
-(playwright.chromium as any).connectOverCDP = (endpointURLOrOptions: (ConnectOverCDPOptions & { wsEndpoint?: string }) | string) => {
+(playwright.chromium as any).connectOverCDP = (endpointURLOrOptions: (ConnectOverCDPOptions & { wsEndpoint?: string }) | string, options?: ConnectOverCDPOptions) => {
+  const connectOptions = typeof endpointURLOrOptions === 'string' ? options : endpointURLOrOptions;
   const wsEndpoint = typeof endpointURLOrOptions === 'string' ? endpointURLOrOptions : endpointURLOrOptions.wsEndpoint ?? endpointURLOrOptions.endpointURL;
   if (!wsEndpoint)
     throw new Error('No wsEndpoint provided');
 
   if (isExternalWebSocketEndpoint(wsEndpoint))
-    return connectToExternalWebSocket(wsEndpoint);
+    return connectToExternalWebSocket(wsEndpoint, connectOptions);
 
   const wsUrl = new URL(wsEndpoint);
   // by default, playwright.chromium.connectOverCDP enforces persistent to true (the default behavior upstream)
@@ -152,12 +153,12 @@ export function endpointURLString(binding: BrowserWorker | BrowserBindingKey, op
   return url.toString();
 }
 
-async function createBrowser(transport: WebSocketTransport, options?: { persistent?: boolean }): Promise<Browser> {
+async function createBrowser(transport: WebSocketTransport, options?: { persistent?: boolean }, connectOptions?: Pick<ConnectOverCDPOptions, 'isLocal' | 'logger' | 'slowMo' | 'timeout'>): Promise<Browser> {
   return await transportZone.run(transport, async () => {
     const url = new URL(WS_FAKE_HOST);
     if (options?.persistent)
       url.searchParams.set('persistent', 'true');
-    const browser = await originalConnectOverCDP.call(playwright.chromium, url.toString(), {}) as Browser;
+    const browser = await originalConnectOverCDP.call(playwright.chromium, url.toString(), connectOptions ?? {}) as Browser;
     // sessionId is undefined for kitesurf browsers
     // The public types express that through the SessionlessBrowser overload of launch().
     browser.sessionId = () => transport.sessionId as string;

--- a/packages/playwright-cloudflare/src/index.ts
+++ b/packages/playwright-cloudflare/src/index.ts
@@ -36,6 +36,10 @@ const originalConnectOverCDP = playwright.chromium.connectOverCDP;
   const wsEndpoint = typeof endpointURLOrOptions === 'string' ? endpointURLOrOptions : endpointURLOrOptions.wsEndpoint ?? endpointURLOrOptions.endpointURL;
   if (!wsEndpoint)
     throw new Error('No wsEndpoint provided');
+
+  if (isExternalWebSocketEndpoint(wsEndpoint))
+    return connectToExternalWebSocket(wsEndpoint);
+
   const wsUrl = new URL(wsEndpoint);
   // by default, playwright.chromium.connectOverCDP enforces persistent to true (the default behavior upstream)
   if (!wsUrl.searchParams.has('persistent'))
@@ -44,6 +48,60 @@ const originalConnectOverCDP = playwright.chromium.connectOverCDP;
     ? connect(wsUrl.toString())
     : launch(wsUrl.toString());
 };
+
+function isExternalWebSocketEndpoint(endpoint: string): boolean {
+  return endpoint.startsWith('ws://') || endpoint.startsWith('wss://');
+}
+
+async function connectToExternalWebSocket(wsEndpoint: string, options?: ConnectOverCDPOptions): Promise<Browser> {
+  resetMonotonicTime();
+  const webSocket = new WebSocket(wsEndpoint);
+  await waitForExternalWebSocketOpen(webSocket, options?.timeout ?? 30_000);
+  const sessionId = new URL(wsEndpoint).searchParams.get('browser_session') ?? '';
+  const transport = new WebSocketTransport(webSocket, sessionId);
+  const browserOptions = options && {
+    isLocal: options.isLocal,
+    logger: options.logger,
+    slowMo: options.slowMo,
+    timeout: options.timeout,
+  };
+  return await createBrowser(transport, { persistent: true }, browserOptions);
+}
+
+function waitForExternalWebSocketOpen(webSocket: WebSocket, timeout: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => {
+      if (timeoutId)
+        clearTimeout(timeoutId);
+      webSocket.removeEventListener('open', onOpen);
+      webSocket.removeEventListener('error', onError);
+      webSocket.removeEventListener('close', onClose);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error('External CDP WebSocket connection failed'));
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error('External CDP WebSocket closed before opening'));
+    };
+    webSocket.addEventListener('open', onOpen);
+    webSocket.addEventListener('error', onError);
+    webSocket.addEventListener('close', onClose);
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        cleanup();
+        webSocket.close();
+        reject(new Error(`Timed out after ${timeout}ms while connecting to external CDP endpoint`));
+      }, timeout);
+    }
+  });
+}
 
 async function connectDevtools(endpoint: BrowserEndpoint, options: { sessionId?: string, persistent?: boolean, browser?: string }): Promise<WebSocket> {
   resetMonotonicTime();

--- a/packages/playwright-cloudflare/tests/src/browser-rendering/session-management.spec.ts
+++ b/packages/playwright-cloudflare/tests/src/browser-rendering/session-management.spec.ts
@@ -120,10 +120,44 @@ test(`should route external WebSocket endpoints through CDP`, async ({ playwrigh
       if (type === 'error')
         queueMicrotask(() => listener(new Error('external CDP test')));
     }
+    removeEventListener() {}
   }
   globalThis.WebSocket = RejectingWebSocket as unknown as typeof WebSocket;
   try {
-    await expect(playwright.chromium.connectOverCDP('wss://example.test/devtools/browser')).rejects.toThrow('external CDP test');
+    await expect(playwright.chromium.connectOverCDP('wss://example.test/devtools/browser')).rejects.toThrow('connection failed');
+  } finally {
+    globalThis.WebSocket = originalWebSocket;
+  }
+});
+
+test(`should reject when external WebSocket closes before opening`, async ({ playwright }) => {
+  const originalWebSocket = globalThis.WebSocket;
+  class ClosingWebSocket {
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      if (type === 'close')
+        queueMicrotask(() => listener(new Event('close')));
+    }
+    removeEventListener() {}
+    close() {}
+  }
+  globalThis.WebSocket = ClosingWebSocket as unknown as typeof WebSocket;
+  try {
+    await expect(playwright.chromium.connectOverCDP('wss://example.test/devtools/browser')).rejects.toThrow('closed before opening');
+  } finally {
+    globalThis.WebSocket = originalWebSocket;
+  }
+});
+
+test(`should time out while opening an external WebSocket`, async ({ playwright }) => {
+  const originalWebSocket = globalThis.WebSocket;
+  class HangingWebSocket {
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+  }
+  globalThis.WebSocket = HangingWebSocket as unknown as typeof WebSocket;
+  try {
+    await expect(playwright.chromium.connectOverCDP('wss://example.test/devtools/browser', { timeout: 1 })).rejects.toThrow('Timed out');
   } finally {
     globalThis.WebSocket = originalWebSocket;
   }

--- a/packages/playwright-cloudflare/tests/src/browser-rendering/session-management.spec.ts
+++ b/packages/playwright-cloudflare/tests/src/browser-rendering/session-management.spec.ts
@@ -113,6 +113,22 @@ test(`should create browser with persistent context on playwright.chromium.conne
   await browser.close();
 });
 
+test(`should route external WebSocket endpoints through CDP`, async ({ playwright }) => {
+  const originalWebSocket = globalThis.WebSocket;
+  class RejectingWebSocket {
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      if (type === 'error')
+        queueMicrotask(() => listener(new Error('external CDP test')));
+    }
+  }
+  globalThis.WebSocket = RejectingWebSocket as unknown as typeof WebSocket;
+  try {
+    await expect(playwright.chromium.connectOverCDP('wss://example.test/devtools/browser')).rejects.toThrow('external CDP test');
+  } finally {
+    globalThis.WebSocket = originalWebSocket;
+  }
+});
+
 test(`should launch browser with no persistent context by default`, async ({ binding }) => {
   const url = endpointURLString(binding);
   const browser = await launch(url);


### PR DESCRIPTION
## Summary

I ran into this while using `@cloudflare/playwright` with external CDP providers and local Chrome. I worked around it in my own fork by adding direct external WebSocket support, and this PR brings that behavior back to the upstream package without changing the existing Cloudflare Browser Run path.

Allow `chromium.connectOverCDP()` to connect directly to external `ws://` and `wss://` CDP endpoints, including Browserbase, Steel, and local Chrome, without treating the endpoint as a Cloudflare Browser Run binding.

## Implementation

- Detect external WebSocket endpoints before the existing Browser Run URL handling.
- Connect using the package's existing WebSocket transport and raw JSON CDP messages.
- Preserve an optional `browser_session` query parameter as the browser session ID.
- Honor the standard connection timeout, including `timeout: 0` to disable it, and forward `slowMo`, `isLocal`, and `logger` to browser creation.
- Reject cleanly when the socket errors, closes before opening, or exceeds the connection timeout.
- Keep the existing Cloudflare Browser Run behavior unchanged.
- Add hermetic Worker tests that verify external WebSocket routing, early-close rejection, and connection timeout behavior.

The standard WebSocket constructor available in Workers does not support arbitrary request headers. External providers should use credentials in their connection URL; `ConnectOverCDPOptions.headers` is not applied to this external-WebSocket path.

This refreshes and supersedes the approach in [#59](https://github.com/cloudflare/playwright/pull/59), without carrying over its obsolete chunking toggle. The implementation is split into commits `614290af0` and `4579a15e0`. Related feature request: [#88](https://github.com/cloudflare/playwright/issues/88).

## Validation

- `npm run build` in `packages/playwright-cloudflare`
- `npm run test:generate:worker`
- Local Wrangler worker test server with the three new external-CDP tests (`3 passed`)
- Focused diff and syntax checks
- The isolated upstream `npm run tsc` check was also attempted; it remains red on pre-existing errors across Playwright's injected code, examples, vendored test submodules, and unchanged Cloudflare wrapper lines. No reported error is on the changed external-CDP lines.

Focused lint reports only pre-existing errors on unchanged upstream lines.
